### PR TITLE
update issuance modules for dseth and gtceth

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,12 +32,12 @@ jobs:
       - run: npm ci
       - run: npm run lint
       - run: npm run build --if-present
-      - run: npm run hardhat & npm run test:btc2x
-      - run: npm run hardhat & npm run test:cdeti
+      # - run: npm run hardhat & npm run test:btc2x
+      # - run: npm run hardhat & npm run test:cdeti
       - run: npm run hardhat & npm run test:dseth
-      - run: npm run hardhat & npm run test:eth2x
-      - run: npm run hardhat & npm run test:gtceth
-      - run: npm run hardhat & npm run test:iceth
+      # - run: npm run hardhat & npm run test:eth2x
+      # - run: npm run hardhat & npm run test:gtceth
+      # - run: npm run hardhat & npm run test:iceth
       # - run: npm run hardhat & npm run test:icreth
       # run last - as it alters the block number
-      - run: npm run hardhat & npm run test:eth2xfli
+      # - run: npm run hardhat & npm run test:eth2xfli

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,12 +32,12 @@ jobs:
       - run: npm ci
       - run: npm run lint
       - run: npm run build --if-present
-      # - run: npm run hardhat & npm run test:btc2x
-      # - run: npm run hardhat & npm run test:cdeti
+      - run: npm run hardhat & npm run test:btc2x
+      - run: npm run hardhat & npm run test:cdeti
       - run: npm run hardhat & npm run test:dseth
-      # - run: npm run hardhat & npm run test:eth2x
+      - run: npm run hardhat & npm run test:eth2x
       - run: npm run hardhat & npm run test:gtceth
-      # - run: npm run hardhat & npm run test:iceth
+      - run: npm run hardhat & npm run test:iceth
       # - run: npm run hardhat & npm run test:icreth
       # run last - as it alters the block number
-      # - run: npm run hardhat & npm run test:eth2xfli
+      - run: npm run hardhat & npm run test:eth2xfli

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,7 +36,7 @@ jobs:
       # - run: npm run hardhat & npm run test:cdeti
       - run: npm run hardhat & npm run test:dseth
       # - run: npm run hardhat & npm run test:eth2x
-      # - run: npm run hardhat & npm run test:gtceth
+      - run: npm run hardhat & npm run test:gtceth
       # - run: npm run hardhat & npm run test:iceth
       # - run: npm run hardhat & npm run test:icreth
       # run last - as it alters the block number

--- a/src/tests/dseth/index.test.ts
+++ b/src/tests/dseth/index.test.ts
@@ -16,7 +16,7 @@ import {
 const { dseth, eth, reth, seth2, steth, usdc, weth, wseth } = QuoteTokens
 const zeroExApi = ZeroExApiSwapQuote
 
-describe.skip('dsETH (mainnet)', () => {
+describe('dsETH (mainnet)', () => {
   let factory: TestFactory
   beforeEach(async () => {
     const provider = LocalhostProvider
@@ -24,7 +24,7 @@ describe.skip('dsETH (mainnet)', () => {
     factory = new TestFactory(provider, signer, zeroExApi)
   })
 
-  test('minting with ETH', async () => {
+  test.only('minting with ETH', async () => {
     await factory.fetchQuote({
       isMinting: true,
       inputToken: eth,

--- a/src/utils/issuanceModules.test.ts
+++ b/src/utils/issuanceModules.test.ts
@@ -41,7 +41,7 @@ describe('getIssuanceModule() - Mainnet - IndexProtocol', () => {
   })
 
   test('returns debt issuance module v2 for dsETH', async () => {
-    const expectedModule = IndexDebtIssuanceModuleV2Address
+    const expectedModule = IndexDebtIssuanceModuleV2Address_v2
     const issuanceModule = getIssuanceModule(DiversifiedStakedETHIndex.symbol)
     expect(issuanceModule.address).toEqual(expectedModule)
     expect(issuanceModule.isDebtIssuance).toBe(true)
@@ -55,7 +55,7 @@ describe('getIssuanceModule() - Mainnet - IndexProtocol', () => {
   })
 
   test('returns debt issuance module v2 for gtcETH', async () => {
-    const expectedModule = IndexDebtIssuanceModuleV2Address
+    const expectedModule = IndexDebtIssuanceModuleV2Address_v2
     const issuanceModule = getIssuanceModule(GitcoinStakedETHIndex.symbol)
     expect(issuanceModule.address).toEqual(expectedModule)
     expect(issuanceModule.isDebtIssuance).toBe(true)

--- a/src/utils/issuanceModules.test.ts
+++ b/src/utils/issuanceModules.test.ts
@@ -55,7 +55,7 @@ describe('getIssuanceModule() - Mainnet - IndexProtocol', () => {
   })
 
   test('returns debt issuance module v2 for gtcETH', async () => {
-    const expectedModule = IndexDebtIssuanceModuleV2Address_v2
+    const expectedModule = IndexDebtIssuanceModuleV2Address
     const issuanceModule = getIssuanceModule(GitcoinStakedETHIndex.symbol)
     expect(issuanceModule.address).toEqual(expectedModule)
     expect(issuanceModule.isDebtIssuance).toBe(true)

--- a/src/utils/issuanceModules.ts
+++ b/src/utils/issuanceModules.ts
@@ -41,6 +41,8 @@ export function getIssuanceModule(
     case ETH2xFlexibleLeverageIndex.symbol:
       return { address: DebtIssuanceModuleAddress, isDebtIssuance: true }
     case CoinDeskEthTrendIndex.symbol:
+    case DiversifiedStakedETHIndex.symbol:
+    case GitcoinStakedETHIndex.symbol:
     case IndexCoopBitcoin2xIndex.symbol:
     case IndexCoopEthereum2xIndex.symbol:
     case LeveragedrEthStakingYield.symbol:
@@ -48,8 +50,6 @@ export function getIssuanceModule(
         address: IndexDebtIssuanceModuleV2Address_v2,
         isDebtIssuance: true,
       }
-    case DiversifiedStakedETHIndex.symbol:
-    case GitcoinStakedETHIndex.symbol:
     case wsETH2.symbol:
       return { address: IndexDebtIssuanceModuleV2Address, isDebtIssuance: true }
     case InterestCompoundingETHIndex.symbol:

--- a/src/utils/issuanceModules.ts
+++ b/src/utils/issuanceModules.ts
@@ -42,7 +42,6 @@ export function getIssuanceModule(
       return { address: DebtIssuanceModuleAddress, isDebtIssuance: true }
     case CoinDeskEthTrendIndex.symbol:
     case DiversifiedStakedETHIndex.symbol:
-    case GitcoinStakedETHIndex.symbol:
     case IndexCoopBitcoin2xIndex.symbol:
     case IndexCoopEthereum2xIndex.symbol:
     case LeveragedrEthStakingYield.symbol:
@@ -50,6 +49,7 @@ export function getIssuanceModule(
         address: IndexDebtIssuanceModuleV2Address_v2,
         isDebtIssuance: true,
       }
+    case GitcoinStakedETHIndex.symbol:
     case wsETH2.symbol:
       return { address: IndexDebtIssuanceModuleV2Address, isDebtIssuance: true }
     case InterestCompoundingETHIndex.symbol:


### PR DESCRIPTION
* Updates dsETH and gtcETH to use the newer DebtIssuanceModuleV2 issuance contract: https://etherscan.io/address/0x04b59F9F09750C044D7CfbC177561E409085f0f3#code

## TODO
- [x] check that all tests are working when the issuances are updated (tested locally, won't enable all to keep actions fast)
- [ ] check gctETH once available
- [x] re-enable all tests once it's working.