### PR TITLE
feat: update quote request amounts to strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ const quote = await quoteProvider.getQuote({
   isMinting: true,
   inputToken,
   outputToken,
-  indexTokenAmount: wei(1),
+  indexTokenAmount: wei(1).toString(),
   slippage: 0.1,
 })
 ```

--- a/src/quote/provider/icusd.ts
+++ b/src/quote/provider/icusd.ts
@@ -21,9 +21,9 @@ export interface IcUsdQuoteRequest extends FlashMintQuoteRequest {
   isMinting: boolean
   inputToken: QuoteToken
   outputToken: QuoteToken
-  indexTokenAmount: BigNumber
+  indexTokenAmount: string
   // FlashMintNav always needs the input amount
-  inputTokenAmount: BigNumber
+  inputTokenAmount: string
   slippage: number
 }
 
@@ -98,8 +98,8 @@ export class IcUsdQuoteRouter
   // }
 
   private async getFlashMintWrappedQuote(request: IcUsdQuoteRequest) {
-    const { chainId, indexTokenAmount, inputToken, isMinting, outputToken } =
-      request
+    const { chainId, inputToken, isMinting, outputToken } = request
+    const indexTokenAmount = BigNumber.from(request.indexTokenAmount)
     const indexToken = isMinting ? outputToken : inputToken
     const inputOutputToken = isMinting ? inputToken : outputToken
     const wrappedQuoteProvider = new WrappedQuoteProvider(
@@ -109,6 +109,7 @@ export class IcUsdQuoteRouter
     const wrappedQuote = await wrappedQuoteProvider.getQuote({
       ...request,
       chainId,
+      indexTokenAmount,
     })
     if (!wrappedQuote) return null
     const builder = new WrappedTransactionBuilder(this.rpcUrl)

--- a/src/quote/provider/index.ts
+++ b/src/quote/provider/index.ts
@@ -40,8 +40,8 @@ export interface FlashMintQuoteRequest {
   isMinting: boolean
   inputToken: QuoteToken
   outputToken: QuoteToken
-  indexTokenAmount: BigNumber
-  inputTokenAmount?: BigNumber
+  indexTokenAmount: string
+  inputTokenAmount?: string
   slippage: number
 }
 
@@ -73,14 +73,9 @@ export class FlashMintQuoteProvider
   ): Promise<FlashMintQuote | null> {
     const { rpcUrl, swapQuoteProvider } = this
     const provider = getRpcProvider(rpcUrl)
-    const {
-      indexTokenAmount,
-      inputTokenAmount,
-      inputToken,
-      isMinting,
-      outputToken,
-      slippage,
-    } = request
+    const { inputToken, inputTokenAmount, isMinting, outputToken, slippage } =
+      request
+    const indexTokenAmount = BigNumber.from(request.indexTokenAmount)
     const indexToken = isMinting ? outputToken : inputToken
     const inputOutputToken = isMinting ? inputToken : outputToken
     const network = await provider.getNetwork()
@@ -151,7 +146,10 @@ export class FlashMintQuoteProvider
           rpcUrl,
           swapQuoteProvider
         )
-        const leveragedQuote = await leveragedQuoteProvider.getQuote(request)
+        const leveragedQuote = await leveragedQuoteProvider.getQuote({
+          ...request,
+          indexTokenAmount,
+        })
         if (!leveragedQuote) return null
         const builder = new LeveragedTransactionBuilder(rpcUrl)
         const txRequest: FlashMintLeveragedBuildRequest = {
@@ -179,7 +177,10 @@ export class FlashMintQuoteProvider
         const leverageExtendedQuoteProvider =
           new LeveragedExtendedQuoteProvider(rpcUrl, swapQuoteProvider)
         const leveragedExtendedQuote =
-          await leverageExtendedQuoteProvider.getQuote(request)
+          await leverageExtendedQuoteProvider.getQuote({
+            ...request,
+            indexTokenAmount,
+          })
         if (!leveragedExtendedQuote) return null
         const builder = new LeveragedExtendedTransactionBuilder(rpcUrl)
         const txRequest: FlashMintLeveragedExtendedBuildRequest = {
@@ -216,6 +217,7 @@ export class FlashMintQuoteProvider
         const wrappedQuote = await wrappedQuoteProvider.getQuote({
           ...request,
           chainId,
+          indexTokenAmount,
         })
         if (!wrappedQuote) return null
         const builder = new WrappedTransactionBuilder(rpcUrl)
@@ -245,7 +247,10 @@ export class FlashMintQuoteProvider
           rpcUrl,
           swapQuoteProvider
         )
-        const zeroExQuote = await zeroExQuoteProvider.getQuote(request)
+        const zeroExQuote = await zeroExQuoteProvider.getQuote({
+          ...request,
+          indexTokenAmount,
+        })
         if (!zeroExQuote) return null
         const builder = new ZeroExTransactionBuilder(rpcUrl)
         const txRequest: FlashMintZeroExBuildRequest = {

--- a/src/quote/provider/utils.test.ts
+++ b/src/quote/provider/utils.test.ts
@@ -1,3 +1,5 @@
+import { getTokenByChainAndSymbol } from '@indexcoop/tokenlists'
+
 import { ChainId } from 'constants/chains'
 import { Contracts } from 'constants/contracts'
 import {
@@ -23,7 +25,8 @@ import { wei } from 'utils'
 import { FlashMintContractType, FlashMintQuoteRequest } from './'
 import { buildQuoteResponse, getContractType } from './utils'
 
-const { icusd, usdc } = QuoteTokens
+const { usdc } = QuoteTokens
+const icusd = getTokenByChainAndSymbol(ChainId.Base, 'icUSD')
 
 describe('buildQuoteResponse()', () => {
   test('returns correct quote response object', async () => {
@@ -31,7 +34,7 @@ describe('buildQuoteResponse()', () => {
       isMinting: true,
       inputToken: usdc,
       outputToken: icusd,
-      indexTokenAmount: wei(1),
+      indexTokenAmount: wei(1).toString(),
       slippage: 0.1,
     }
     const quoteAmount = wei(100, 6)

--- a/src/quote/provider/utils.test.ts
+++ b/src/quote/provider/utils.test.ts
@@ -1,3 +1,4 @@
+import { BigNumber } from '@ethersproject/bignumber'
 import { getTokenByChainAndSymbol } from '@indexcoop/tokenlists'
 
 import { ChainId } from 'constants/chains'
@@ -57,8 +58,8 @@ describe('buildQuoteResponse()', () => {
       inputToken: usdc,
       outputToken: icusd,
       inputAmount: quoteAmount,
-      outputAmount: request.indexTokenAmount,
-      indexTokenAmount: request.indexTokenAmount,
+      outputAmount: BigNumber.from(request.indexTokenAmount),
+      indexTokenAmount: BigNumber.from(request.indexTokenAmount),
       inputOutputAmount: quoteAmount,
       slippage: 0.1,
       tx,

--- a/src/quote/provider/utils.ts
+++ b/src/quote/provider/utils.ts
@@ -37,8 +37,8 @@ export function buildQuoteResponse(
   inputOutputTokenAmount: BigNumber, // quote amount
   tx: TransactionRequest
 ): FlashMintQuote {
-  const { isMinting, indexTokenAmount, inputToken, outputToken, slippage } =
-    request
+  const { isMinting, inputToken, outputToken, slippage } = request
+  const indexTokenAmount = BigNumber.from(request.indexTokenAmount)
   return {
     chainId,
     contractType,

--- a/src/tests/arbitrum/btc2x.test.ts
+++ b/src/tests/arbitrum/btc2x.test.ts
@@ -29,7 +29,7 @@ describe('BTC2X (Arbitrum)', () => {
       isMinting: true,
       inputToken: eth,
       outputToken: btc2x,
-      indexTokenAmount: wei('1'),
+      indexTokenAmount: wei('1').toString(),
       slippage: 0.5,
     })
     await factory.executeTx()
@@ -40,7 +40,7 @@ describe('BTC2X (Arbitrum)', () => {
       isMinting: false,
       inputToken: btc2x,
       outputToken: eth,
-      indexTokenAmount: wei('1'),
+      indexTokenAmount: wei('1').toString(),
       slippage: 0.5,
     })
     await factory.executeTx()

--- a/src/tests/arbitrum/btc3x.test.ts
+++ b/src/tests/arbitrum/btc3x.test.ts
@@ -29,7 +29,7 @@ describe.skip('BTC3X (Arbitrum)', () => {
       isMinting: true,
       inputToken: eth,
       outputToken: eth3x,
-      indexTokenAmount: wei('1'),
+      indexTokenAmount: wei('1').toString(),
       slippage: 1,
     })
     await factory.executeTx()
@@ -40,7 +40,7 @@ describe.skip('BTC3X (Arbitrum)', () => {
       isMinting: false,
       inputToken: eth3x,
       outputToken: eth,
-      indexTokenAmount: wei('1'),
+      indexTokenAmount: wei('1').toString(),
       slippage: 1,
     })
     await factory.executeTx()

--- a/src/tests/arbitrum/eth2x.test.ts
+++ b/src/tests/arbitrum/eth2x.test.ts
@@ -29,7 +29,7 @@ describe('ETH2X (Arbitrum)', () => {
       isMinting: true,
       inputToken: eth,
       outputToken: eth2x,
-      indexTokenAmount: wei('1'),
+      indexTokenAmount: wei('1').toString(),
       slippage: 0.5,
     })
     await factory.executeTx()
@@ -40,7 +40,7 @@ describe('ETH2X (Arbitrum)', () => {
       isMinting: false,
       inputToken: eth2x,
       outputToken: eth,
-      indexTokenAmount: wei('1'),
+      indexTokenAmount: wei('1').toString(),
       slippage: 0.5,
     })
     await factory.executeTx()

--- a/src/tests/arbitrum/eth3x.test.ts
+++ b/src/tests/arbitrum/eth3x.test.ts
@@ -29,7 +29,7 @@ describe('ETH3X (Arbitrum)', () => {
       isMinting: true,
       inputToken: eth,
       outputToken: eth3x,
-      indexTokenAmount: wei('1'),
+      indexTokenAmount: wei('1').toString(),
       slippage: 0.5,
     })
     await factory.executeTx()
@@ -40,7 +40,7 @@ describe('ETH3X (Arbitrum)', () => {
       isMinting: false,
       inputToken: eth3x,
       outputToken: eth,
-      indexTokenAmount: wei('1'),
+      indexTokenAmount: wei('1').toString(),
       slippage: 0.5,
     })
     await factory.executeTx()

--- a/src/tests/arbitrum/ibtc1x.test.ts
+++ b/src/tests/arbitrum/ibtc1x.test.ts
@@ -29,7 +29,7 @@ describe('iBTC1X (Arbitrum)', () => {
       isMinting: true,
       inputToken: eth,
       outputToken: ibtc1x,
-      indexTokenAmount: wei('1'),
+      indexTokenAmount: wei('1').toString(),
       slippage: 0.5,
     })
     await factory.executeTx()
@@ -40,7 +40,7 @@ describe('iBTC1X (Arbitrum)', () => {
       isMinting: false,
       inputToken: ibtc1x,
       outputToken: eth,
-      indexTokenAmount: wei('1'),
+      indexTokenAmount: wei('1').toString(),
       slippage: 0.5,
     })
     await factory.executeTx()

--- a/src/tests/arbitrum/ieth1x.test.ts
+++ b/src/tests/arbitrum/ieth1x.test.ts
@@ -29,7 +29,7 @@ describe('iETH1X (Arbitrum)', () => {
       isMinting: true,
       inputToken: eth,
       outputToken: ieth1x,
-      indexTokenAmount: wei('1'),
+      indexTokenAmount: wei('1').toString(),
       slippage: 0.5,
     })
     await factory.executeTx()
@@ -40,7 +40,7 @@ describe('iETH1X (Arbitrum)', () => {
       isMinting: false,
       inputToken: ieth1x,
       outputToken: eth,
-      indexTokenAmount: wei('1'),
+      indexTokenAmount: wei('1').toString(),
       slippage: 0.5,
     })
     await factory.executeTx()

--- a/src/tests/base/eth2x.test.ts
+++ b/src/tests/base/eth2x.test.ts
@@ -31,7 +31,7 @@ describe('ETH2X (Base)', () => {
       isMinting: true,
       inputToken: eth,
       outputToken: eth2x,
-      indexTokenAmount: wei('1'),
+      indexTokenAmount: wei('1').toString(),
       slippage: 0.5,
     })
     await factory.executeTx()
@@ -42,7 +42,7 @@ describe('ETH2X (Base)', () => {
       isMinting: false,
       inputToken: eth2x,
       outputToken: eth,
-      indexTokenAmount: wei('1'),
+      indexTokenAmount: wei('1').toString(),
       slippage: 0.5,
     })
     await factory.executeTx()

--- a/src/tests/base/eth3x.test.ts
+++ b/src/tests/base/eth3x.test.ts
@@ -31,7 +31,7 @@ describe.skip('ETH3X (Base)', () => {
       isMinting: true,
       inputToken: eth,
       outputToken: eth3x,
-      indexTokenAmount: wei('1'),
+      indexTokenAmount: wei('1').toString(),
       slippage: 0.5,
     })
     await factory.executeTx()
@@ -42,7 +42,7 @@ describe.skip('ETH3X (Base)', () => {
       isMinting: false,
       inputToken: eth3x,
       outputToken: eth,
-      indexTokenAmount: wei('1'),
+      indexTokenAmount: wei('1').toString(),
       slippage: 0.5,
     })
     await factory.executeTx()

--- a/src/tests/btc2x.test.ts
+++ b/src/tests/btc2x.test.ts
@@ -21,7 +21,7 @@ describe('BTC2X (mainnet)', () => {
       isMinting: true,
       inputToken: eth,
       outputToken: btc2x,
-      indexTokenAmount: wei('1'),
+      indexTokenAmount: wei('1').toString(),
       slippage: 0.5,
     })
     await factory.executeTx()
@@ -33,7 +33,7 @@ describe('BTC2X (mainnet)', () => {
       isMinting: true,
       inputToken: eth,
       outputToken: btc2x,
-      indexTokenAmount: wei('1'),
+      indexTokenAmount: wei('1').toString(),
       slippage: 0.5,
     })
     await factory.executeTx()
@@ -44,7 +44,7 @@ describe('BTC2X (mainnet)', () => {
       isMinting: false,
       inputToken: btc2x,
       outputToken: eth,
-      indexTokenAmount: wei('1'),
+      indexTokenAmount: wei('1').toString(),
       slippage: 0.5,
     })
     await factory.executeTx()

--- a/src/tests/dseth/index.test.ts
+++ b/src/tests/dseth/index.test.ts
@@ -26,7 +26,7 @@ describe('dsETH (mainnet)', () => {
       isMinting: true,
       inputToken: eth,
       outputToken: dseth,
-      indexTokenAmount: wei('0.1'),
+      indexTokenAmount: wei('0.1').toString(),
       slippage: 1,
     })
     await factory.executeTx()
@@ -37,7 +37,7 @@ describe('dsETH (mainnet)', () => {
       isMinting: false,
       inputToken: dseth,
       outputToken: eth,
-      indexTokenAmount: wei('0.1'),
+      indexTokenAmount: wei('0.1').toString(),
       slippage: 1,
     })
     await factory.executeTx()
@@ -48,7 +48,7 @@ describe('dsETH (mainnet)', () => {
       isMinting: true,
       inputToken: weth,
       outputToken: dseth,
-      indexTokenAmount: wei('0.1'),
+      indexTokenAmount: wei('0.1').toString(),
       slippage: 1,
     })
     await wrapETH(quote.inputOutputAmount, factory.getSigner())
@@ -60,7 +60,7 @@ describe('dsETH (mainnet)', () => {
       isMinting: false,
       inputToken: dseth,
       outputToken: weth,
-      indexTokenAmount: wei('0.1'),
+      indexTokenAmount: wei('0.1').toString(),
       slippage: 1,
     })
     await factory.executeTx()
@@ -71,7 +71,7 @@ describe('dsETH (mainnet)', () => {
       isMinting: true,
       inputToken: reth,
       outputToken: dseth,
-      indexTokenAmount: wei('0.1'),
+      indexTokenAmount: wei('0.1').toString(),
       slippage: 1,
     })
     const rethWhale = '0x7d6149aD9A573A6E2Ca6eBf7D4897c1B766841B4'
@@ -90,7 +90,7 @@ describe('dsETH (mainnet)', () => {
       isMinting: false,
       inputToken: dseth,
       outputToken: reth,
-      indexTokenAmount: wei('0.1'),
+      indexTokenAmount: wei('0.1').toString(),
       slippage: 1,
     })
     await factory.executeTx()
@@ -101,7 +101,7 @@ describe('dsETH (mainnet)', () => {
       isMinting: true,
       inputToken: seth2,
       outputToken: dseth,
-      indexTokenAmount: wei('0.1'),
+      indexTokenAmount: wei('0.1').toString(),
       slippage: 1,
     })
     // ETH / sETH2
@@ -126,7 +126,7 @@ describe('dsETH (mainnet)', () => {
       isMinting: false,
       inputToken: dseth,
       outputToken: seth2,
-      indexTokenAmount: wei('0.1'),
+      indexTokenAmount: wei('0.1').toString(),
       slippage: 1,
     })
     await factory.executeTx()
@@ -137,7 +137,7 @@ describe('dsETH (mainnet)', () => {
       isMinting: true,
       inputToken: steth,
       outputToken: dseth,
-      indexTokenAmount: wei('0.1'),
+      indexTokenAmount: wei('0.1').toString(),
       slippage: 1,
     })
     await addLiquidityToLido(wei('2'), factory.getSigner())
@@ -149,7 +149,7 @@ describe('dsETH (mainnet)', () => {
       isMinting: false,
       inputToken: dseth,
       outputToken: steth,
-      indexTokenAmount: wei('0.1'),
+      indexTokenAmount: wei('0.1').toString(),
       slippage: 1,
     })
     await factory.executeTx()
@@ -160,7 +160,7 @@ describe('dsETH (mainnet)', () => {
       isMinting: true,
       inputToken: usdc,
       outputToken: dseth,
-      indexTokenAmount: wei('0.1'),
+      indexTokenAmount: wei('0.1').toString(),
       slippage: 1,
     })
     const whale = '0x7713974908Be4BEd47172370115e8b1219F4A5f0'
@@ -179,7 +179,7 @@ describe('dsETH (mainnet)', () => {
       isMinting: false,
       inputToken: dseth,
       outputToken: usdc,
-      indexTokenAmount: wei('0.1'),
+      indexTokenAmount: wei('0.1').toString(),
       slippage: 1,
     })
     await factory.executeTx()
@@ -190,7 +190,7 @@ describe('dsETH (mainnet)', () => {
       isMinting: true,
       inputToken: wseth,
       outputToken: dseth,
-      indexTokenAmount: wei('0.1'),
+      indexTokenAmount: wei('0.1').toString(),
       slippage: 1,
     })
     const signer = factory.getSigner()
@@ -205,7 +205,7 @@ describe('dsETH (mainnet)', () => {
       isMinting: false,
       inputToken: dseth,
       outputToken: wseth,
-      indexTokenAmount: wei('0.1'),
+      indexTokenAmount: wei('0.1').toString(),
       slippage: 1,
     })
     await factory.executeTx()

--- a/src/tests/eth2x.test.ts
+++ b/src/tests/eth2x.test.ts
@@ -21,7 +21,7 @@ describe('ETH2X (mainnet)', () => {
       isMinting: true,
       inputToken: eth,
       outputToken: eth2x,
-      indexTokenAmount: wei('1'),
+      indexTokenAmount: wei('1').toString(),
       slippage: 0.5,
     })
     await factory.executeTx()
@@ -33,7 +33,7 @@ describe('ETH2X (mainnet)', () => {
       isMinting: true,
       inputToken: eth,
       outputToken: eth2x,
-      indexTokenAmount: wei('1'),
+      indexTokenAmount: wei('1').toString(),
       slippage: 0.5,
     })
     await factory.executeTx()
@@ -44,7 +44,7 @@ describe('ETH2X (mainnet)', () => {
       isMinting: false,
       inputToken: eth2x,
       outputToken: eth,
-      indexTokenAmount: wei('1'),
+      indexTokenAmount: wei('1').toString(),
       slippage: 0.5,
     })
     await factory.executeTx()
@@ -56,7 +56,7 @@ describe('ETH2X (mainnet)', () => {
       isMinting: false,
       inputToken: eth2x,
       outputToken: eth,
-      indexTokenAmount: wei('1'),
+      indexTokenAmount: wei('1').toString(),
       slippage: 0.5,
     })
     await factory.executeTx()

--- a/src/tests/gtceth/index.test.ts
+++ b/src/tests/gtceth/index.test.ts
@@ -22,7 +22,7 @@ describe.skip('gtcETH (mainnet)', () => {
       isMinting: true,
       inputToken: eth,
       outputToken: gtcETH,
-      indexTokenAmount: wei('0.1'),
+      indexTokenAmount: wei('0.1').toString(),
       slippage: 0.5,
     })
     await factory.executeTx()

--- a/src/tests/hyeth.test.ts
+++ b/src/tests/hyeth.test.ts
@@ -26,7 +26,7 @@ describe('hyETH', () => {
       isMinting: true,
       inputToken: eth,
       outputToken: indexToken,
-      indexTokenAmount: wei('1'),
+      indexTokenAmount: wei('1').toString(),
       slippage: 0.5,
     })
     await factory.executeTx()
@@ -38,7 +38,7 @@ describe('hyETH', () => {
       isMinting: true,
       inputToken: usdc,
       outputToken: indexToken,
-      indexTokenAmount: wei('1'),
+      indexTokenAmount: wei('1').toString(),
       slippage: 0.5,
     })
     const whale = '0x7713974908Be4BEd47172370115e8b1219F4A5f0'
@@ -58,7 +58,7 @@ describe('hyETH', () => {
       isMinting: false,
       inputToken: indexToken,
       outputToken: eth,
-      indexTokenAmount: wei('1'),
+      indexTokenAmount: wei('1').toString(),
       slippage: 0.5,
     })
     await factory.executeTx()
@@ -71,7 +71,7 @@ describe('hyETH', () => {
       isMinting: true,
       inputToken: eth,
       outputToken: indexToken,
-      indexTokenAmount: wei('1'),
+      indexTokenAmount: wei('1').toString(),
       slippage: 0.5,
     })
     await factory.executeTx()
@@ -82,7 +82,7 @@ describe('hyETH', () => {
       isMinting: true,
       inputToken: eth,
       outputToken: indexToken,
-      indexTokenAmount: wei('550'),
+      indexTokenAmount: wei('550').toString(),
       slippage: 0.5,
     })
     await factory.executeTx()
@@ -93,7 +93,7 @@ describe('hyETH', () => {
       isMinting: true,
       inputToken: usdc,
       outputToken: indexToken,
-      indexTokenAmount: wei('1'),
+      indexTokenAmount: wei('1').toString(),
       slippage: 0.5,
     })
     const whale = '0x7713974908Be4BEd47172370115e8b1219F4A5f0'
@@ -112,7 +112,7 @@ describe('hyETH', () => {
       isMinting: false,
       inputToken: indexToken,
       outputToken: eth,
-      indexTokenAmount: wei('1'),
+      indexTokenAmount: wei('1').toString(),
       slippage: 0.5,
     })
     const whale = '0x6e2C509D522d47F509E1a6D75682E6AbBC38B362'
@@ -131,7 +131,7 @@ describe('hyETH', () => {
       isMinting: false,
       inputToken: indexToken,
       outputToken: eth,
-      indexTokenAmount: wei('200'),
+      indexTokenAmount: wei('200').toString(),
       slippage: 0.5,
     })
     await factory.executeTx()
@@ -142,7 +142,7 @@ describe('hyETH', () => {
       isMinting: false,
       inputToken: indexToken,
       outputToken: eth,
-      indexTokenAmount: wei('1'),
+      indexTokenAmount: wei('1').toString(),
       slippage: 0.5,
     })
     const whale = '0x6e2C509D522d47F509E1a6D75682E6AbBC38B362'

--- a/src/tests/ic21.test.ts
+++ b/src/tests/ic21.test.ts
@@ -22,7 +22,7 @@ describe('ic21 (mainnet)', () => {
       isMinting: true,
       inputToken: eth,
       outputToken: ic21,
-      indexTokenAmount: wei('1'),
+      indexTokenAmount: wei('1').toString(),
       slippage: 0.5,
     })
     await factory.executeTx()
@@ -33,7 +33,7 @@ describe('ic21 (mainnet)', () => {
       isMinting: true,
       inputToken: usdc,
       outputToken: ic21,
-      indexTokenAmount: wei('1'),
+      indexTokenAmount: wei('1').toString(),
       slippage: 0.5,
     })
     const usdcWhale = '0x7713974908Be4BEd47172370115e8b1219F4A5f0'
@@ -52,7 +52,7 @@ describe('ic21 (mainnet)', () => {
       isMinting: true,
       inputToken: weth,
       outputToken: ic21,
-      indexTokenAmount: wei('1'),
+      indexTokenAmount: wei('1').toString(),
       slippage: 0.5,
     })
     await wrapETH(quote.inputOutputAmount, factory.getSigner())
@@ -64,7 +64,7 @@ describe('ic21 (mainnet)', () => {
       isMinting: false,
       inputToken: ic21,
       outputToken: eth,
-      indexTokenAmount: wei('1'),
+      indexTokenAmount: wei('1').toString(),
       slippage: 0.5,
     })
     await factory.executeTx()
@@ -75,7 +75,7 @@ describe('ic21 (mainnet)', () => {
       isMinting: false,
       inputToken: ic21,
       outputToken: usdc,
-      indexTokenAmount: wei('1'),
+      indexTokenAmount: wei('1').toString(),
       slippage: 0.5,
     })
     await factory.executeTx()

--- a/src/tests/iceth.test.ts
+++ b/src/tests/iceth.test.ts
@@ -24,7 +24,7 @@ describe('icETH (mainnet)', () => {
       isMinting: true,
       inputToken: eth,
       outputToken: iceth,
-      indexTokenAmount: wei('1'),
+      indexTokenAmount: wei('1').toString(),
       slippage: 0.5,
     })
     await factory.executeTx()
@@ -36,7 +36,7 @@ describe('icETH (mainnet)', () => {
       isMinting: true,
       inputToken: eth,
       outputToken: iceth,
-      indexTokenAmount: wei('1'),
+      indexTokenAmount: wei('1').toString(),
       slippage: 0.5,
     })
     await factory.executeTx()
@@ -47,7 +47,7 @@ describe('icETH (mainnet)', () => {
       isMinting: false,
       inputToken: iceth,
       outputToken: eth,
-      indexTokenAmount: wei('1'),
+      indexTokenAmount: wei('1').toString(),
       slippage: 0.5,
     })
     await factory.executeTx(BigNumber.from(5_000_000))
@@ -58,7 +58,7 @@ describe('icETH (mainnet)', () => {
       isMinting: true,
       inputToken: weth,
       outputToken: iceth,
-      indexTokenAmount: wei('0.1'),
+      indexTokenAmount: wei('0.1').toString(),
       slippage: 1,
     })
     await wrapETH(quote.inputOutputAmount, factory.getSigner())
@@ -71,7 +71,7 @@ describe('icETH (mainnet)', () => {
       isMinting: true,
       inputToken: weth,
       outputToken: iceth,
-      indexTokenAmount: wei('0.1'),
+      indexTokenAmount: wei('0.1').toString(),
       slippage: 1,
     })
     await wrapETH(quote.inputOutputAmount, factory.getSigner())
@@ -83,7 +83,7 @@ describe('icETH (mainnet)', () => {
       isMinting: false,
       inputToken: iceth,
       outputToken: weth,
-      indexTokenAmount: wei('0.1'),
+      indexTokenAmount: wei('0.1').toString(),
       slippage: 1,
     })
     await factory.executeTx()

--- a/src/tests/icusd.test.ts
+++ b/src/tests/icusd.test.ts
@@ -31,9 +31,9 @@ describe('icUSD (Base)', () => {
       isMinting: true,
       inputToken: usdc,
       outputToken: indexToken,
-      indexTokenAmount: wei(1),
+      indexTokenAmount: wei(1).toString(),
       // Irrelevant - as right now we don't use FlashMintNav
-      inputTokenAmount: BigNumber.from(0),
+      inputTokenAmount: '0',
       slippage: 0.5,
     })
     await transferFromWhale(
@@ -51,9 +51,9 @@ describe('icUSD (Base)', () => {
       isMinting: true,
       inputToken: weth,
       outputToken: indexToken,
-      indexTokenAmount: wei(1),
+      indexTokenAmount: wei(1).toString(),
       // Irrelevant - as right now we don't use FlashMintNav
-      inputTokenAmount: BigNumber.from(0),
+      inputTokenAmount: '0',
       slippage: 0.5,
     })
     await wrapETH(
@@ -69,9 +69,9 @@ describe('icUSD (Base)', () => {
       isMinting: true,
       inputToken: getTokenByChainAndSymbol(chainId, 'DAI'),
       outputToken: indexToken,
-      indexTokenAmount: wei(1),
+      indexTokenAmount: wei(1).toString(),
       // Irrelevant - as right now we don't use FlashMintNav
-      inputTokenAmount: BigNumber.from(0),
+      inputTokenAmount: '0',
       slippage: 0.5,
     })
     await transferFromWhale(
@@ -90,8 +90,8 @@ describe('icUSD (Base)', () => {
       inputToken: indexToken,
       outputToken: usdc,
       // In case of redeeming input and index token amount are the same
-      indexTokenAmount: wei('1'),
-      inputTokenAmount: wei('1'),
+      indexTokenAmount: wei('1').toString(),
+      inputTokenAmount: wei('1').toString(),
       slippage: 0.5,
     })
     await factory.executeTx()
@@ -103,8 +103,8 @@ describe('icUSD (Base)', () => {
       inputToken: indexToken,
       outputToken: weth,
       // In case of redeeming input and index token amount are the same
-      indexTokenAmount: wei('1'),
-      inputTokenAmount: wei('1'),
+      indexTokenAmount: wei('1').toString(),
+      inputTokenAmount: wei('1').toString(),
       slippage: 0.5,
     })
     await factory.executeTx()

--- a/src/tests/utils/test-factory.ts
+++ b/src/tests/utils/test-factory.ts
@@ -107,7 +107,7 @@ export class TestFactory {
     expect(quote).toBeDefined()
     if (!quote) fail()
     expect(quote.isMinting).toEqual(config.isMinting)
-    expect(quote.indexTokenAmount).toEqual(config.indexTokenAmount)
+    expect(quote.indexTokenAmount.toString()).toEqual(config.indexTokenAmount)
     expect(quote.inputOutputAmount.gt(0)).toBe(true)
     this.quote = quote
     return quote


### PR DESCRIPTION
* Changes quote request amounts to `string`, so that clients do not have to deal wit BigNumber or BigInt or can choose freely which one to use.