### PR TITLE
feat: add slippage for preview amounts

### DIFF
--- a/src/utils/component-swap-data.ts
+++ b/src/utils/component-swap-data.ts
@@ -207,7 +207,11 @@ async function getAmount(
       functionName: isMinting ? 'previewMint' : 'previewRedeem',
       args: [issuanceUnits],
     })) as bigint
-    return preview
+    if (isMinting) {
+      return (preview * BigInt(10001)) / BigInt(10000)
+    } else {
+      return (preview * BigInt(9999)) / BigInt(10000)
+    }
   } catch {
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const usdc = getTokenByChainAndSymbol(chainId, 'USDC')!


### PR DESCRIPTION
Some morpho components seem to have a tiny diff in preview amounts during execution. So this PR adds a small slippage (0.01%) to the output of the previewMint/Redeem functions.