### PR TITLE
fix: hyeth quotes for erc20's

### DIFF
--- a/src/quote/flashmint/hyeth/component-quotes/index.ts
+++ b/src/quote/flashmint/hyeth/component-quotes/index.ts
@@ -86,7 +86,12 @@ export class ComponentQuotesProvider {
       const amount = positions[index].toBigInt()
 
       if (isAddressEqual(component, this.wethAddress)) {
-        quotePromises.push(Promise.resolve(amount))
+        if (
+          isAddressEqual(inputTokenAddress, this.wethAddress) ||
+          isAddressEqual(outputTokenAddress, this.wethAddress)
+        ) {
+          quotePromises.push(Promise.resolve(amount))
+        }
       }
 
       if (this.isAcross(component)) {

--- a/src/tests/hyeth.test.ts
+++ b/src/tests/hyeth.test.ts
@@ -7,6 +7,7 @@ import {
   TestFactory,
   transferFromWhale,
   wei,
+  wrapETH,
 } from './utils'
 
 describe('hyETH', () => {
@@ -31,6 +32,18 @@ describe('hyETH', () => {
     await factory.executeTx()
   })
 
+  test.skip('can mint with WETH', async () => {
+    const quote = await factory.fetchQuote({
+      isMinting: true,
+      inputToken: getTokenByChainAndSymbol(chainId, 'WETH'),
+      outputToken: indexToken,
+      indexTokenAmount: wei('3').toString(),
+      slippage: 0.5,
+    })
+    await wrapETH(quote.inputAmount, factory.getSigner(), chainId)
+    await factory.executeTx()
+  })
+
   test.skip('can mint with ETH (large amout)', async () => {
     await factory.fetchQuote({
       isMinting: true,
@@ -42,7 +55,7 @@ describe('hyETH', () => {
     await factory.executeTx()
   })
 
-  test.skip('can mint with USDC', async () => {
+  test('can mint with USDC', async () => {
     const quote = await factory.fetchQuote({
       isMinting: true,
       inputToken: usdc,

--- a/src/utils/component-swap-data.test.ts
+++ b/src/utils/component-swap-data.test.ts
@@ -138,7 +138,8 @@ describe('getRedemptionComponentSwapData()', () => {
       const dexData = componentSwapData[i].dexData
       expect(dexData.exchange).toEqual(Exchange.UniV3)
       expect(dexData.fees.length).toBeGreaterThan(0)
-      expect(dexData.path).toEqual([usdc.toLowerCase(), weth])
+      expect(dexData.path[0]).toEqual(usdc.toLowerCase())
+      expect(dexData.path[1]).toEqual(weth)
       expect(dexData.pool).toEqual(AddressZero)
       expect(dexData.poolIds).toEqual([])
       expect(


### PR DESCRIPTION
Fixes hyETH quotes for ERC20's by temporarily ignoring the WETH dust - which otherwise leads to decimals issues of the quote amount.