### PR TITLE
feat: parallelize swap quotes

### DIFF
--- a/src/quote/flashmint/hyeth/component-quotes/morpho.ts
+++ b/src/quote/flashmint/hyeth/component-quotes/morpho.ts
@@ -71,8 +71,7 @@ export class MorphoQuoteProvider {
     if (
       swapQuoteResult &&
       swapQuoteResult.status === 'fulfilled' &&
-      swapQuoteResult.value !== null &&
-      swapQuoteResult.value !== undefined
+      swapQuoteResult.value
     ) {
       return BigInt(swapQuoteResult.value.inputAmount)
     }


### PR DESCRIPTION
As per @ckoopmann idea parallelizes the lifi and its fallback (getSellAmount) swap quotes. Update hyETH and LeveragedZeroEx accordingly. `ZeroEx` does not need any updates - as it's redeeming only - and 0x swap quotes are currently sufficient for that.