### PR TITLE
fix: quoting

### DIFF
--- a/src/quote/flashmint/hyeth/component-quotes/morpho.ts
+++ b/src/quote/flashmint/hyeth/component-quotes/morpho.ts
@@ -71,7 +71,10 @@ export class MorphoQuoteProvider {
     if (swapQuote?.inputAmount != null) {
       return BigInt(swapQuote.inputAmount)
     }
-    return (await sellAmountPromise).toBigInt()
+
+    const sellAmount = await sellAmountPromise
+    if (sellAmount === null) return null
+    return sellAmount.toBigInt()
   }
 
   async getRedeemQuote(

--- a/src/quote/flashmint/hyeth/component-quotes/morpho.ts
+++ b/src/quote/flashmint/hyeth/component-quotes/morpho.ts
@@ -1,3 +1,4 @@
+import { BigNumber } from '@ethersproject/bignumber'
 import { Contract } from '@ethersproject/contracts'
 import { isAddressEqual } from '@indexcoop/tokenlists'
 
@@ -6,8 +7,7 @@ import { WETH } from 'constants/tokens'
 import { getSellAmount } from 'quote/flashmint/leveraged-zeroex/utils'
 import { getRpcProvider } from 'utils/rpc-provider'
 
-import { BigNumber } from '@ethersproject/bignumber'
-import type { SwapQuoteProviderV2 } from 'quote/swap'
+import type { SwapQuoteProviderV2, ZeroExV2SwapQuoteProvider } from 'quote/swap'
 
 export class MorphoQuoteProvider {
   readonly taker = Contracts[1].FlashMintHyEthV3
@@ -65,6 +65,7 @@ export class MorphoQuoteProvider {
       minBuyAmount,
       maxBuyAmount,
       maxSellAmount,
+      this.swapQuoteProvider as ZeroExV2SwapQuoteProvider,
     )
 
     const swapQuote = await swapQuotePromise

--- a/src/quote/flashmint/leveraged-zeroex/fallback.ts
+++ b/src/quote/flashmint/leveraged-zeroex/fallback.ts
@@ -1,7 +1,7 @@
 import { getSellAmount } from 'quote/flashmint/leveraged-zeroex/utils'
 
 import type { BigNumber } from '@ethersproject/bignumber'
-import type { SwapQuoteProviderV2, SwapQuoteRequestV2 } from 'quote/swap'
+import type { SwapQuoteRequestV2, ZeroExV2SwapQuoteProvider } from 'quote/swap'
 import type { FlashMintLeveragedZeroExQuoteRequest } from './provider'
 
 export async function getFallbackQuote(
@@ -12,7 +12,7 @@ export async function getFallbackQuote(
   maxBuyAmount: BigNumber,
   maxSellAmount: BigNumber,
   request: FlashMintLeveragedZeroExQuoteRequest,
-  swapQuoteProvider: SwapQuoteProviderV2,
+  swapQuoteProvider: ZeroExV2SwapQuoteProvider,
 ) {
   const { chainId, slippage, taker } = request
 
@@ -24,6 +24,7 @@ export async function getFallbackQuote(
     minBuyAmount,
     maxBuyAmount,
     maxSellAmount,
+    swapQuoteProvider,
   )
 
   if (!sellAmount) {

--- a/src/quote/flashmint/leveraged-zeroex/fallback.ts
+++ b/src/quote/flashmint/leveraged-zeroex/fallback.ts
@@ -26,6 +26,11 @@ export async function getFallbackQuote(
     maxSellAmount,
   )
 
+  if (!sellAmount) {
+    console.warn('Can not determine sell amount for fallback quote')
+    return null
+  }
+
   const quoteRequest: SwapQuoteRequestV2 = {
     chainId,
     inputToken,

--- a/src/quote/flashmint/leveraged-zeroex/provider.ts
+++ b/src/quote/flashmint/leveraged-zeroex/provider.ts
@@ -22,6 +22,7 @@ import type {
   SwapQuoteProviderV2,
   SwapQuoteRequestV2,
   SwapQuoteV2,
+  ZeroExV2SwapQuoteProvider,
 } from '../../swap'
 
 export interface FlashMintLeveragedZeroExQuoteRequest {
@@ -164,7 +165,7 @@ export class LeveragedZeroExQuoteProvider
       maxBuyAmount,
       BigNumber.from(leveragedTokenData.collateralAmount.toString()),
       request,
-      this.swapQuoteProvider,
+      this.swapQuoteProvider as ZeroExV2SwapQuoteProvider,
     )
 
     // Should await quoteOutputPromise first and only wait for fallback promise if first one returns nullish value
@@ -306,7 +307,7 @@ export class LeveragedZeroExQuoteProvider
           maxBuyAmount,
           BigNumber.from(inputAmount),
           request,
-          this.swapQuoteProvider,
+          this.swapQuoteProvider as ZeroExV2SwapQuoteProvider,
         )
 
         // Should await quoteOutputPromise first and only wait for fallback promise if first one returns nullish value

--- a/src/quote/flashmint/leveraged-zeroex/utils.ts
+++ b/src/quote/flashmint/leveraged-zeroex/utils.ts
@@ -53,7 +53,8 @@ export async function getSellAmount(
   maxRequests = 10,
 ) {
   if (targetBuyAmount.gt(maxBuyAmount) || targetBuyAmount.lt(minBuyAmount)) {
-    throw new Error('targetBuyAmount not in range')
+    console.warn('targetBuyAmount not in range')
+    return null
   }
   let response = await getZeroExResponse(
     chainId,
@@ -64,9 +65,10 @@ export async function getSellAmount(
   let sellAmount = BigNumber.from(response.sellAmount)
   let buyAmount = BigNumber.from(response.buyAmount)
   if (buyAmount.lt(minBuyAmount)) {
-    throw new Error(
+    console.warn(
       `Buy amount obtained for maxSellAmount (${buyAmount.toString()}) is less than specified minBuyAmount ${minBuyAmount.toString()}`,
     )
+    return null
   }
   let requestNum = 0
   while (
@@ -80,7 +82,8 @@ export async function getSellAmount(
     requestNum++
   }
   if (buyAmount.lt(minBuyAmount) || buyAmount.gt(maxBuyAmount)) {
-    throw new Error('exceeded max requests')
+    console.warn('exceeded max requests')
+    return null
   }
   return sellAmount
 }

--- a/src/quote/flashmint/leveraged-zeroex/utils.ts
+++ b/src/quote/flashmint/leveraged-zeroex/utils.ts
@@ -1,46 +1,7 @@
 import { BigNumber } from '@ethersproject/bignumber'
 import { getTokenByChainAndSymbol, isAddressEqual } from '@indexcoop/tokenlists'
-import axios from 'axios'
 
-export async function getZeroExResponse(
-  chainId: number,
-  sellToken: string,
-  buyToken: string,
-  sellAmount: BigNumber,
-  taker: string | undefined = undefined,
-  isQuote = false,
-  sellEntireBalance = true,
-): Promise<any> {
-  if (isQuote && taker === undefined) {
-    throw new Error('taker is required when getting actual quote')
-  }
-  const priceParams = new URLSearchParams({
-    chainId: chainId.toString(),
-    sellToken,
-    buyToken,
-    sellAmount: sellAmount.toString(),
-  })
-  if (taker !== undefined) {
-    priceParams.append('taker', taker)
-  }
-  if (
-    sellEntireBalance &&
-    !isAddressEqual(sellToken, getTokenByChainAndSymbol(1, 'stETH').address)
-  ) {
-    priceParams.append('sellEntireBalance', 'true')
-  }
-
-  const headers = {
-    '0x-api-key': process.env.ZEROEX_API_KEY,
-    '0x-version': 'v2',
-  }
-
-  const endpoint = isQuote ? 'quote' : 'price'
-  const url = `https://api.0x.org/swap/allowance-holder/${endpoint}?${priceParams.toString()}`
-
-  const response = await axios.get(url, { headers })
-  return response.data
-}
+import type { ZeroExV2SwapQuoteProvider } from 'quote/swap/adapters/zeroex_v2'
 
 export async function getSellAmount(
   chainId: number,
@@ -50,20 +11,33 @@ export async function getSellAmount(
   minBuyAmount: BigNumber,
   maxBuyAmount: BigNumber,
   maxSellAmount: BigNumber,
+  swapQuoteProvider: ZeroExV2SwapQuoteProvider,
   maxRequests = 10,
 ) {
   if (targetBuyAmount.gt(maxBuyAmount) || targetBuyAmount.lt(minBuyAmount)) {
     console.warn('targetBuyAmount not in range')
     return null
   }
-  let response = await getZeroExResponse(
-    chainId,
+
+  const isStEth = isAddressEqual(
     sellToken,
-    buyToken,
-    maxSellAmount,
+    getTokenByChainAndSymbol(1, 'stETH').address,
   )
-  let sellAmount = BigNumber.from(response.sellAmount)
-  let buyAmount = BigNumber.from(response.buyAmount)
+  let response = await swapQuoteProvider.getPriceQuote({
+    chainId,
+    inputToken: sellToken,
+    outputToken: buyToken,
+    slippage: 0.5,
+    inputAmount: maxSellAmount.toString(),
+    sellEntireBalance: !isStEth,
+  })
+  if (!response) {
+    console.warn('Initial price response is null for getSellAmount()')
+    return null
+  }
+
+  let sellAmount = BigNumber.from(response?.inputAmount)
+  let buyAmount = BigNumber.from(response?.outputAmount)
   if (buyAmount.lt(minBuyAmount)) {
     console.warn(
       `Buy amount obtained for maxSellAmount (${buyAmount.toString()}) is less than specified minBuyAmount ${minBuyAmount.toString()}`,
@@ -76,13 +50,25 @@ export async function getSellAmount(
     requestNum < maxRequests
   ) {
     sellAmount = sellAmount.mul(targetBuyAmount).div(buyAmount)
-    response = await getZeroExResponse(chainId, sellToken, buyToken, sellAmount)
-    buyAmount = BigNumber.from(response.buyAmount)
-    sellAmount = BigNumber.from(response.sellAmount)
+    response = await swapQuoteProvider.getPriceQuote({
+      chainId,
+      inputToken: sellToken,
+      outputToken: buyToken,
+      slippage: 0.5,
+      inputAmount: sellAmount.toString(),
+      sellEntireBalance: !isStEth,
+    })
+    if (response) {
+      buyAmount = BigNumber.from(response.outputAmount)
+      sellAmount = BigNumber.from(response.inputAmount)
+    } else {
+      console.warn('Response is null for getSellAmount()')
+      return null
+    }
     requestNum++
   }
   if (buyAmount.lt(minBuyAmount) || buyAmount.gt(maxBuyAmount)) {
-    console.warn('exceeded max requests')
+    console.warn('Exceeded max requests')
     return null
   }
   return sellAmount

--- a/src/quote/flashmint/zeroEx/provider.ts
+++ b/src/quote/flashmint/zeroEx/provider.ts
@@ -45,7 +45,8 @@ export class ZeroExQuoteProvider
       request
 
     if (isMinting) {
-      throw new Error('Minting not supported.')
+      console.warn('Minting not supported.')
+      return null
     }
 
     const indexToken = isMinting ? outputToken : inputToken

--- a/src/quote/swap/adapters/lifi/index.ts
+++ b/src/quote/swap/adapters/lifi/index.ts
@@ -25,7 +25,12 @@ export class LiFiSwapQuoteProvider implements SwapQuoteProviderV2 {
     } = request
 
     if ((!inputAmount && !outputAmount) || (inputAmount && outputAmount)) {
-      throw new Error('Error - either input or output amount must be set')
+      console.warn(
+        'Error - either input or output amount must be set',
+        inputToken,
+        outputToken,
+      )
+      return null
     }
 
     try {
@@ -45,7 +50,8 @@ export class LiFiSwapQuoteProvider implements SwapQuoteProviderV2 {
       )
 
       if (!result || !result.transactionRequest) {
-        throw new Error('no estimate')
+        console.warn('No Li.Fi estimate')
+        return null
       }
 
       return {

--- a/src/quote/swap/adapters/lifi/index.ts
+++ b/src/quote/swap/adapters/lifi/index.ts
@@ -67,7 +67,7 @@ export class LiFiSwapQuoteProvider implements SwapQuoteProviderV2 {
         },
       }
     } catch (error) {
-      console.log('Error getting LiFi swap quote.')
+      console.warn('Error getting LiFi swap quote.')
       return null
     }
   }

--- a/src/quote/swap/adapters/zeroex_v2/client.ts
+++ b/src/quote/swap/adapters/zeroex_v2/client.ts
@@ -5,14 +5,20 @@ import type {
   ZeroExApiV2SwapResponseNoLiquidity,
 } from './types'
 
-export async function getClientV2(path: string, apiKey: string) {
+export async function getClientV2(
+  path: string,
+  apiKey: string,
+  isPriceQuote = false,
+) {
   const config = {
     headers: {
       '0x-api-key': apiKey,
       '0x-version': 'v2',
     },
   }
-  const url = `https://api.0x.org/swap/allowance-holder/quote?${path}`
+  const endpoint = isPriceQuote ? 'price' : 'quote'
+  const url = `https://api.0x.org/swap/allowance-holder/${endpoint}?${path}`
+  console.log(url)
   const res = await axios.get(url, config)
   return res.data as
     | ZeroExApiV2SwapResponse

--- a/src/quote/swap/adapters/zeroex_v2/client.ts
+++ b/src/quote/swap/adapters/zeroex_v2/client.ts
@@ -18,7 +18,6 @@ export async function getClientV2(
   }
   const endpoint = isPriceQuote ? 'price' : 'quote'
   const url = `https://api.0x.org/swap/allowance-holder/${endpoint}?${path}`
-  console.log(url)
   const res = await axios.get(url, config)
   return res.data as
     | ZeroExApiV2SwapResponse

--- a/src/quote/swap/adapters/zeroex_v2/index.ts
+++ b/src/quote/swap/adapters/zeroex_v2/index.ts
@@ -12,6 +12,8 @@ import {
 } from './utils'
 
 import type {
+  SwapPriceQuoteV2,
+  SwapPriceRequestV2,
   SwapQuoteProviderV2,
   SwapQuoteRequestV2,
   SwapQuoteV2,
@@ -20,6 +22,42 @@ import type { ZeroExApiV2SwapResponse } from './types'
 
 export class ZeroExV2SwapQuoteProvider implements SwapQuoteProviderV2 {
   constructor(readonly apiKey: string) {}
+
+  async getPriceQuote(
+    request: SwapPriceRequestV2,
+  ): Promise<SwapPriceQuoteV2 | null> {
+    const { chainId, inputToken, outputToken, inputAmount, slippage } = request
+    const path = this.getPath(request)
+    const isPriceQuote = true
+    const res = await getClientV2(path, this.apiKey, isPriceQuote)
+
+    if (!res.liquidityAvailable) {
+      // throw new ZeroExV2SwapQuoteProviderError(
+      //   ZeroExV2SwapQuoteProviderErrorType.insufficientLiquidity,
+      //   'Insufficient liquidity for swap',
+      // )
+      console.warn('Price quote error: Insufficient liquidity for swap')
+      return null
+    }
+
+    if (!isZeroExApiV2SwapResponse(res)) {
+      console.warn(
+        'Price quote error: Invalid response format from ZeroEx API v2',
+      )
+      return null
+    }
+
+    const swapResponse: ZeroExApiV2SwapResponse = res
+
+    return {
+      chainId,
+      inputToken,
+      outputToken,
+      inputAmount: swapResponse.sellAmount,
+      outputAmount: swapResponse.buyAmount,
+      slippage,
+    }
+  }
 
   async getSwapQuote(request: SwapQuoteRequestV2): Promise<SwapQuoteV2 | null> {
     const { chainId, inputToken, outputToken, slippage } = request
@@ -54,15 +92,17 @@ export class ZeroExV2SwapQuoteProvider implements SwapQuoteProviderV2 {
     }
   }
 
-  getPath(request: SwapQuoteRequestV2): string {
+  getPath(request: SwapQuoteRequestV2 | SwapPriceRequestV2): string {
     const params: any = {
       chainId: request.chainId.toString(),
       buyToken: request.outputToken,
       sellToken: request.inputToken,
       sellAmount: request.inputAmount,
-      taker: request.taker,
       slippageBps: convertTo0xSlippage(request.slippage).toString(),
       excludedSources: getExcludedSources(request.chainId),
+    }
+    if (request.taker) {
+      params.taker = request.taker
     }
     if (
       request.sellEntireBalance === true &&

--- a/src/quote/swap/adapters/zeroex_v2/index.ts
+++ b/src/quote/swap/adapters/zeroex_v2/index.ts
@@ -34,7 +34,8 @@ export class ZeroExV2SwapQuoteProvider implements SwapQuoteProviderV2 {
     }
 
     if (!isZeroExApiV2SwapResponse(res)) {
-      throw new Error('Invalid response format from ZeroEx API')
+      console.warn('Invalid response format from ZeroEx API v2')
+      return null
     }
 
     const swapResponse: ZeroExApiV2SwapResponse = res

--- a/src/quote/swap/adapters/zeroex_v2/utils.ts
+++ b/src/quote/swap/adapters/zeroex_v2/utils.ts
@@ -1,4 +1,5 @@
 import { Exchange } from 'utils'
+import { arbitrum } from 'viem/chains'
 import type { ZeroExApiV2SwapResponse } from './types'
 
 /**
@@ -31,7 +32,8 @@ export const exchangeFrom0xSource: { [key: string]: Exchange } = {
 // docs: https://0x.org/docs/api#tag/Sources
 export function getExcludedSources(chainId: number) {
   switch (chainId) {
-    // For now, no need to exclude any sources.
+    case arbitrum.id:
+      return 'WOOFi_V2'
     default:
       return ''
   }

--- a/src/quote/swap/adapters/zeroex_v2/utils.ts
+++ b/src/quote/swap/adapters/zeroex_v2/utils.ts
@@ -1,5 +1,5 @@
 import { Exchange } from 'utils'
-import { arbitrum } from 'viem/chains'
+import { arbitrum, base } from 'viem/chains'
 import type { ZeroExApiV2SwapResponse } from './types'
 
 /**
@@ -33,6 +33,8 @@ export const exchangeFrom0xSource: { [key: string]: Exchange } = {
 export function getExcludedSources(chainId: number) {
   switch (chainId) {
     case arbitrum.id:
+      return 'WOOFi_V2'
+    case base.id:
       return 'WOOFi_V2'
     default:
       return ''

--- a/src/quote/swap/interfaces.ts
+++ b/src/quote/swap/interfaces.ts
@@ -1,5 +1,14 @@
 import type { Exchange, SwapDataV2 } from 'utils'
 
+export interface SwapPriceQuoteV2 {
+  chainId: number
+  inputToken: string
+  outputToken: string
+  inputAmount: string
+  outputAmount: string
+  slippage: number
+}
+
 export interface SwapQuoteV2 {
   chainId: number
   inputToken: string
@@ -8,6 +17,17 @@ export interface SwapQuoteV2 {
   outputAmount: string
   slippage: number
   swapData: SwapDataV2 | null
+}
+
+// Currently only used for 0x API v2
+export interface SwapPriceRequestV2 {
+  chainId: number
+  inputToken: string
+  outputToken: string
+  inputAmount: string
+  slippage: number
+  sellEntireBalance: boolean
+  taker?: string
 }
 
 export interface SwapQuoteRequestV2 {

--- a/src/tests/base/btc2x.test.ts
+++ b/src/tests/base/btc2x.test.ts
@@ -29,20 +29,20 @@ describe('BTC2X (Base)', () => {
       outputToken: indexToken,
       indexTokenAmount: wei('1').toString(),
       inputTokenAmount: wei('0.5').toString(),
-      slippage: 0.5,
+      slippage: 1.5,
     })
     await factory.executeTx()
   })
 
-  test.only('can mint with cbBTC', async () => {
+  test('can mint with cbBTC', async () => {
     const quote = await factory.fetchQuote({
       chainId,
       isMinting: true,
       inputToken: cbbtc,
       outputToken: indexToken,
       indexTokenAmount: wei('1').toString(),
-      inputTokenAmount: wei('0.01').toString(),
-      slippage: 0.5,
+      inputTokenAmount: wei('0.2').toString(),
+      slippage: 1.5,
     })
     const whale = '0x9d719096fF38c8D6652Cd95233e58452f4F4a2f0'
     await transferFromWhale(
@@ -62,8 +62,8 @@ describe('BTC2X (Base)', () => {
       inputToken: usdc,
       outputToken: indexToken,
       indexTokenAmount: wei('1').toString(),
-      inputTokenAmount: wei('500').toString(),
-      slippage: 0.5,
+      inputTokenAmount: wei('1500').toString(),
+      slippage: 1.5,
     })
     const whale = '0x621e7c767004266c8109e83143ab0Da521B650d6'
     await transferFromWhale(


### PR DESCRIPTION
Fixes quoting by...
* using 0x v2 swap quote provider for `getSellAmount()` because this might not have been picking up the env vars - and so possibly fails due to rate limits
* excluding woofi as a source for Arbitrum and Base (due to failing tx's)
* failing more gracefully in some instances (logging warnings instead of throwing error; should be improved in further PRs)