### PR TITLE
fix: slippage

### DIFF
--- a/src/quote/swap/adapters/zeroex_v2/utils.test.ts
+++ b/src/quote/swap/adapters/zeroex_v2/utils.test.ts
@@ -20,6 +20,18 @@ describe('convertTo0xSlippage()', () => {
   })
 
   it('should convert slippage to 0x slippage format (bps)', () => {
+    const slippage = 1.093097
+    const result = convertTo0xSlippage(slippage)
+    expect(result).toBe(109)
+  })
+
+  it('should convert slippage to 0x slippage format (bps)', () => {
+    const slippage = 1.1
+    const result = convertTo0xSlippage(slippage)
+    expect(result).toBe(110)
+  })
+
+  it('should convert slippage to 0x slippage format (bps)', () => {
     const slippage = 0
     const result = convertTo0xSlippage(slippage)
     expect(result).toBe(0)

--- a/src/quote/swap/adapters/zeroex_v2/utils.ts
+++ b/src/quote/swap/adapters/zeroex_v2/utils.ts
@@ -3,14 +3,16 @@ import { arbitrum, base } from 'viem/chains'
 import type { ZeroExApiV2SwapResponse } from './types'
 
 /**
- * Converts slippage to 0x slippage format (bps)
+ * Converts slippage to 0x slippage format (bps).
+ * The given value will be rounded to avoid issues with floating-point numbers.
  * @param slippage The slippage to convert to bps where 0.1 = 0.1%
  * @returns slippage in bps (0x format)
  */
 export function convertTo0xSlippage(slippage: number): number {
   if (slippage < 0) return 0
   if (slippage > 100) return 100
-  return slippage * 100
+  // Must be rounded to avoid potential issues with floating-point numbers.
+  return Math.round(slippage * 100)
 }
 
 export function isZeroExApiV2SwapResponse(


### PR DESCRIPTION
## Description
Fixes slippage values introducing rounding. Specifically, where floating-point numbers e.g. 1.093097 or as simple as 1.1 could cause issues.

## Resources
* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/EPSILON